### PR TITLE
The env variable for Octopus API Key didn't match what's used in code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ Promoted 2.5.202.5 from Test to QA
 ### OCTOPUS_URL_BASE
 This environment variable is the base of your octopus installation. For example, `http://octopus.yourcompany.com`
 
-### OCTOPUS_API_KEY
+### OCTOPUS_KEY
 The octopus api key needed to call the octopus API
 


### PR DESCRIPTION
Changed variable name from OCTOPUS_API_KEY to OCTOPUS_KEY in readme.
